### PR TITLE
Consumer facing metrics

### DIFF
--- a/basic_functions.py
+++ b/basic_functions.py
@@ -1,0 +1,11 @@
+# We will use this file to define basic functions used in multiple notebooks
+
+def get_data_from_csv():
+    """df import with some alterations we discovered so far
+    Parses dates, drops 'CountryCode' and 'CurrencyCode' columns, sets appropriate dtypes.
+    Returns:
+        DataFrame: A dataframe with the imported data
+    """
+
+    import pandas as pd
+    return pd.read_csv('data/xente/training.csv', parse_dates=['TransactionStartTime'], dtype={'ProductId': 'category','ProductCategory': 'category','ChannelId': 'category','PricingStrategy': 'category'}, index_col='TransactionId').drop(['CountryCode', 'CurrencyCode'], axis=1)

--- a/functions.py
+++ b/functions.py
@@ -1,1 +1,0 @@
-#we will use this file to define functions used in multiple notebooks

--- a/xente_consumer_facing_metrics.py
+++ b/xente_consumer_facing_metrics.py
@@ -1,0 +1,47 @@
+import numpy as np
+def get_money_saved(y_pred, y_true, x_values):
+    
+    # get boolean mask for the predicted true values
+    y_pred_fraud_mask = (y_pred == 1)
+    # get boolean mask for the actual true values
+    y_true_fraud_mask = (y_true == 1)
+
+    # get boolean mask for true positives
+    y_saved_mask = (y_pred_fraud_mask & y_true_fraud_mask)
+
+    # find the value (in money) for each of the true positives
+    saved_values = x_values[y_saved_mask]
+
+    # return the sum of the monetary value of the true positives
+    return x_values[y_saved_mask].sum()
+
+def get_money_left_on_table(y_pred, y_true, x_values):
+    # get boolean mask for the predicted false values
+    y_pred_fraud_mask = (y_pred == 0)
+    # get boolean mask for the actual true values
+    y_true_fraud_mask = (y_true == 1)
+
+    # get boolean mask for true positives
+    y_missed_mask = (y_pred_fraud_mask & y_true_fraud_mask)
+
+    # find the value (in money) for each of the false negatives
+    missed_values = x_values[y_missed_mask]
+
+    # return the sum of the monetary value of the true positives
+    return x_values[y_missed_mask].sum()
+
+def get_annoyance_index(y_pred, y_true, coefficient=1):
+    
+    # get indices the predicted true values
+    y_pred_fraud_mask = (y_pred == 1)
+    # get the indices for the actual false values
+    y_non_fraud_mask = (y_true == 0)
+
+    # get boolean mask for false positives
+    y_fp_mask = (y_pred_fraud_mask & y_non_fraud_mask)
+
+    # count the false positives and multiply by coefficient
+    annoyance_index = y_fp_mask.sum() * coefficient
+
+    # return the sum of the value of the true positives
+    return annoyance_index


### PR DESCRIPTION
Added consumer-facing metrics. To use them, add the following the `Baseline_model.ipynb`:
```python
from xente_consumer_facing_metrics import *
money_saved = get_money_saved(y_pred=y_pred_base, y_true=y_test.values, x_values=X_test["Value"].values)
print(f"We saved ${money_saved} that otherwise would have been spend on drugs and weapons.")

money_left_on_table = get_money_left_on_table(y_pred=y_pred_base, y_true=y_test.values, x_values=X_test["Value"].values)
print(f"We left ${money_left_on_table} on the table.")
annoyance_index = get_annoyance_index(y_pred=y_pred_base, y_true=y_test.values, coefficient=1)
print(f"We ruined {annoyance_index} of our customers' days.")
```
